### PR TITLE
Exclude author_email from additional_info 

### DIFF
--- a/ckanext/data_qld_theme/templates/package/snippets/additional_info.html
+++ b/ckanext/data_qld_theme/templates/package/snippets/additional_info.html
@@ -1,0 +1,19 @@
+{% ckan_extends %}
+
+{%- set exclude_fields = [
+  'id',
+  'title',
+  'name',
+  'notes',
+  'tag_string',
+  'license_id',
+  'owner_org',
+  ] -%}
+
+{%- if h.data_qld_user_has_admin_access(True) == False -%}
+  {%- do exclude_fields.append('author_email') -%}
+{%- endif -%}
+
+{% block package_additional_info %}
+ {{ super() }}
+{% endblock %}


### PR DESCRIPTION
for non-sysadmin/admin/editor users