### PR TITLE
Demo feedback - 14 June 2019

### DIFF
--- a/ckanext/data_qld_theme/templates/datarequests/snippets/datarequest_form.html
+++ b/ckanext/data_qld_theme/templates/datarequests/snippets/datarequest_form.html
@@ -14,7 +14,7 @@
 {% endblock %}
 
 {% block offering_title %}
-{{ form.input('title', id='field-title', label=_('Subject'), placeholder=_('eg. Data Request Name'), value=title, error=errors['Title'], classes=['control-full', 'control-large'], is_required=true) }}
+{{ form.input('title', id='field-title', label=_('Subject'), placeholder=_('eg. Data Request Name'), value=title, error=errors['Title'], classes=['control-full'], is_required=true) }}
 {% endblock %}
 
 

--- a/ckanext/data_qld_theme/templates/package/resource_read.html
+++ b/ckanext/data_qld_theme/templates/package/resource_read.html
@@ -108,3 +108,13 @@
   {{ super() }}
 {% endblock %}
 {% endblock %}
+
+{% block resource_read_title %}
+	{% if res.schema %}
+		<h1 class="page-heading">{{ h.resource_display_name(res) | truncate(50) }}
+		{{ h.get_validation_badge(res)|safe }}
+		</h1>
+
+		{% resource 'ckanext-validation/main' %}
+	{% endif %}
+{% endblock %}

--- a/ckanext/data_qld_theme/templates/scheming/snippets/display_field.html
+++ b/ckanext/data_qld_theme/templates/scheming/snippets/display_field.html
@@ -24,7 +24,7 @@
     entity_type=entity_type, object_type=object_type -%}
 {%- else -%}
   {%- if field.field_name.lower() == 'url' and field.label.lower() == 'source' -%}
-    Field name '{{field.field_name}}' not applicable
+    Not applicable
   {%- else -%}
     Field name '{{field.field_name}}' not in data
   {%- endif -%}

--- a/ckanext/data_qld_theme/templates/scheming/snippets/display_field.html
+++ b/ckanext/data_qld_theme/templates/scheming/snippets/display_field.html
@@ -23,5 +23,9 @@
   {%- snippet display_snippet, field=field, data=data, errors=errors,
     entity_type=entity_type, object_type=object_type -%}
 {%- else -%}
-  Field name '{{field.field_name}}' not in data
+  {%- if field.field_name.lower() == 'url' and field.label.lower() == 'source' -%}
+    Field name '{{field.field_name}}' not applicable
+  {%- else -%}
+    Field name '{{field.field_name}}' not in data
+  {%- endif -%}
 {%- endif -%}

--- a/ckanext/data_qld_theme/templates/scheming/snippets/display_field.html
+++ b/ckanext/data_qld_theme/templates/scheming/snippets/display_field.html
@@ -15,7 +15,7 @@
   {%- set display_snippet = 'scheming/display_snippets/' + display_snippet -%}
 {%- endif -%}
 
-{%- if field.field_name in data -%}
+{%- if field.field_name in data and data[field.field_name]|length -%}
   {%- snippet display_snippet, field=field, data=data, errors=errors,
     entity_type=entity_type, object_type=object_type -%}
 {%- elif field.field_name|title in data -%}

--- a/ckanext/data_qld_theme/templates/snippets/organization.html
+++ b/ckanext/data_qld_theme/templates/snippets/organization.html
@@ -1,0 +1,6 @@
+{% ckan_extends %}
+
+{% block image %}
+
+{% endblock %}
+    


### PR DESCRIPTION
Don't display Organisation images
If no validation schema is submitted on a resource, then do not display the "data valid" button/ badge
Data Request form - subject label input box should be same size font as description field
When the dataset is not a link the Source field in the additional info section shows