### PR TITLE
[DQL-188, DQL2-24, DQL2-26, DQL2-27] EPIC - Dataset comment enhancements

### DIFF
--- a/ckanext/data_qld_theme/templates/datarequests/show.html
+++ b/ckanext/data_qld_theme/templates/datarequests/show.html
@@ -27,6 +27,6 @@
   {{ h.build_nav_icon('show_datarequest', _('Data request'), id=datarequest_id) }}
 
   {% if h.show_comments_tab() and h.ytp_comments_enabled() %}
-    {{ h.build_nav_icon('comment_datarequest', _('Comments') + ' ' + h.get_datarequest_comments_badge(datarequest_id), id=datarequest_id) }}
+    {{ h.build_nav_icon('comment_datarequest', _('Comments') + ' ' + h.get_content_type_comments_badge(datarequest_id, 'datarequest'), id=datarequest_id) }}
   {% endif %}
 {% endblock %}

--- a/ckanext/data_qld_theme/templates/datarequests/snippets/datarequest_item.html
+++ b/ckanext/data_qld_theme/templates/datarequests/snippets/datarequest_item.html
@@ -19,7 +19,7 @@
       {% endif %}
       <div class="datarequest-properties">
         {% if h.show_comments_tab() and h.ytp_comments_enabled() %}
-          <a href="{{ h.url_for(controller='ckanext.datarequests.controllers.ui_controller:DataRequestsUI', action='comment', id=datarequest.get('id','')) }}" class="label label-default"><i class="icon-comment fa fa-comment"></i>{{ h.get_datarequest_comments_badge(datarequest.get('id', '')) }}</a>
+          <a href="{{ h.url_for(controller='ckanext.datarequests.controllers.ui_controller:DataRequestsUI', action='comment', id=datarequest.get('id','')) }}" class="label label-default"><i class="icon-comment fa fa-comment"></i>{{ h.get_content_type_comments_badge(datarequest.get('id', ''), 'datarequest') }}</a>
         {% endif %}
         <div class="divider"/>
         <span class="date-datarequests">{{ h.time_ago_from_timestamp(datarequest.open_time) }}</span>

--- a/ckanext/data_qld_theme/templates/package/comment_list.html
+++ b/ckanext/data_qld_theme/templates/package/comment_list.html
@@ -90,12 +90,12 @@
                         {% endif %}
                     {% endif %}
                     <div class="comment-header-text">
+                        {% set commented_on = 'commented on ' + h.render_datetime(comment.creation_date, "%d %b %Y, %-I:%M%p") %}
                         {% if 'user_state' in comment and comment.user_state == 'deleted' %}
-                            <em>{{ comment.user_login_name }}</em>
+                            <em>{{ comment.user_login_name }}</em> {{ commented_on }}
                         {% else %}
-                            {{  h.linked_user(comment.user_id, 0, 0) }}
+                            {% link_for _(comment.user_login_name), controller='user', action='read', id=comment.user_id %} {{ commented_on }}
                         {% endif %}
-                        commented on {{ h.render_datetime(comment.creation_date, "%d %b %Y, %-I:%M%p") }}
                         {% if comment.modified_date %}
                         &mdash; <small>({{ _('Modified') }} {{ h.render_datetime(comment.modified_date, "%d %b %Y, %-I:%M%p") }})</small>
                         {% endif %}
@@ -109,7 +109,7 @@
                         <h3>{{ comment.subject }}</h3>
                     {% endif %}
                 {% else %}
-                    <p><strong>{{ _('This comment was deleted.') }}</strong></p>
+                    {% snippet "snippets/comment_deleted.html", comment=comment %}
                 {% endif %}
                 {% if comment.state != 'deleted' %}
                     <div class="content">

--- a/ckanext/data_qld_theme/templates/scheming/package/read.html
+++ b/ckanext/data_qld_theme/templates/scheming/package/read.html
@@ -6,17 +6,3 @@
     <li class="active"><a href="{{ h.url_for(controller='package', action='read', id=pkg.name) }}">{{ pkg.title }}</a></li>
 {% endblock %}
 
-{% block package_notes %}
-
-    {% resource "odi_certificates/odi_certificate.js" %}
-    {% resource "odi_certificates/odi_certificate.css" %}
-
-    <div id="odi_certificates"
-      data-module="odi_certificates"
-      data-module-certificate_api_urls="{{ h.odi_certificates_certificate_api_urls()}}"">
-        {% snippet "package/snippets/odi_certificate.html" %}
-    </div>
-
-    {{ super() }}
-
-{% endblock %}


### PR DESCRIPTION
- [DQL2-27] Added user link with username for comment
- [DQL2-24] Added new badge snippet
- [DQL2-24] Refactored get_datarequest_comments_badge to get_content_type_comments_badge so it can be used for different content_types
- [DQL2-26] Added comment deleted by header text
- [DQL2-26] Refactored comment header text
- [DQL2-26] Display comment deleter adjustments
  - Removed ODI certificate output from dataset detail template (`scheming/package/read.html`)
  - Abstracted deleted message to snippet in ckanext-ytp-comments extension
  - Added support for legacy deleted comments with no `comment.deleted_by_user_id` value