### PR TITLE
QLD Open Data Sprint 2

### DIFF
--- a/ckanext/data_qld_theme/fanstatic/dataset-deletion-confirm-action.js
+++ b/ckanext/data_qld_theme/fanstatic/dataset-deletion-confirm-action.js
@@ -35,7 +35,7 @@ ckan.module('dataset-deletion-confirm-action', function (jQuery) {
                 '<div class="modal-body">',
                 '<br/><br/>',
                 '<div class="modal-reason">Briefly describe the reason for deleting this dataset:<br/>',
-                '<input id="reason" name="deletion_reason" type="text" class="form-control"/></div>',
+                '<input id="reason" name="deletion_reason" type="text" class="form-control" maxlength="250" /></div>',
                 '</div>',
                 '<div class="modal-footer">',
                 '<button class="btn btn-default btn-cancel"></button>',

--- a/ckanext/data_qld_theme/fanstatic/dataset-deletion-confirm-action.js
+++ b/ckanext/data_qld_theme/fanstatic/dataset-deletion-confirm-action.js
@@ -1,0 +1,151 @@
+ckan.module('dataset-deletion-confirm-action', function (jQuery) {
+    return {
+        /* An object of module options */
+        options: {
+            /* Content can be overriden by setting data-module-content to a
+             * *translated* string inside the template, e.g.
+             *
+             *     <a href="..."
+             *        data-module="confirm-action"
+             *        data-module-content="{{ _('Are you sure?') }}">
+             *    {{ _('Delete') }}
+             *    </a>
+             */
+            content: '',
+
+            /* This is part of the old i18n system and is kept for backwards-
+             * compatibility for templates which set the content via the
+             * `i18n.content` attribute instead of via the `content` attribute
+             * as described above.
+             */
+            i18n: {
+                content: '',
+            },
+
+            href: '',
+
+            template: [
+                '<div class="modal fade">',
+                '<div class="modal-dialog">',
+                '<div class="modal-content">',
+                '<div class="modal-header">',
+                '<button type="button" class="close" data-dismiss="modal">×</button>',
+                '<h3 class="modal-title"></h3>',
+                '</div>',
+                '<div class="modal-body">',
+                '<br/><br/>',
+                '<div class="modal-reason">Briefly describe the reason for deleting this dataset:<br/>',
+                '<input id="reason" name="deletion_reason" type="text" class="form-control"/></div>',
+                '</div>',
+                '<div class="modal-footer">',
+                '<button class="btn btn-default btn-cancel"></button>',
+                '<button class="btn btn-primary" disabled="disabled"></button>',
+                '</div>',
+                '</div>',
+                '</div>',
+                '</div>'
+            ].join('\n')
+        },
+
+        deletion_reason: '',
+
+        /* Sets up the event listeners for the object. Called internally by
+         * module.createInstance().
+         *
+         * Returns nothing.
+         */
+        initialize: function () {
+            jQuery.proxyAll(this, /_on/);
+            this.el.removeAttr('disabled');
+            this.el.on('click', this._onClick);
+        },
+
+        /* Presents the user with a confirm dialogue to ensure that they wish to
+         * continue with the current action.
+         *
+         * Examples
+         *
+         *   jQuery('.delete').click(function () {
+         *     module.confirm();
+         *   });
+         *
+         * Returns nothing.
+         */
+        confirm: function () {
+            this.sandbox.body.append(this.createModal());
+            this.modal.modal('show');
+
+            // Center the modal in the middle of the screen.
+            this.modal.css({
+                'margin-top': this.modal.height() * -0.5,
+                'top': '50%'
+            });
+        },
+
+        /* Performs the action for the current item.
+         *
+         * Returns nothing.
+         */
+        performAction: function () {
+            // create a form and submit it to confirm the deletion
+            var form = jQuery('<form/>', {
+                action: this.options.href,
+                method: 'POST'
+            });
+
+            form.append('<input type="hidden" name="deletion_reason" value="' + this.deletion_reason + '">');
+            form.appendTo('body').submit();
+        },
+
+        /* Creates the modal dialog, attaches event listeners and localised
+         * strings.
+         *
+         * Returns the newly created element.
+         */
+        createModal: function () {
+            if (!this.modal) {
+                var element = this.modal = jQuery(this.options.template);
+                element.on('click', '.btn-primary', this._onConfirmSuccess);
+                element.on('click', '.btn-cancel', this._onConfirmCancel);
+                element.on('keyup', '#reason', this._onKeyUp);
+                element.modal({show: false});
+
+                element.find('.modal-title').text(this._('Please Confirm Action'));
+                var content = this.options.content ||
+                    this.options.i18n.content || /* Backwards-compatibility */
+                    this._('Are you sure you want to perform this action?');
+                element.find('.modal-body').prepend(content);
+                element.find('.btn-primary').text(this._('Confirm'));
+                element.find('.btn-cancel').text(this._('Cancel'));
+            }
+            return this.modal;
+        },
+
+        /* Event handler that displays the confirm dialog */
+        _onClick: function (event) {
+            event.preventDefault();
+            this.confirm();
+        },
+
+        /* Event handler for the success event */
+        _onConfirmSuccess: function (event) {
+            this.performAction();
+        },
+
+        /* Event handler for the cancel event */
+        _onConfirmCancel: function (event) {
+            this.modal.modal('hide');
+        },
+
+        _onKeyUp: function (event) {
+            var value = jQuery(event.target).val().trim();
+            if (value.length >= 10) {
+                this.deletion_reason = value;
+                this.modal.find('.modal-footer .btn-primary').removeAttr('disabled');
+            } else {
+                this.deletion_reason = '';
+                this.modal.find('.modal-footer .btn-primary').attr('disabled', 'disabled');
+            }
+        }
+    };
+});

--- a/ckanext/data_qld_theme/templates/package/comment_list.html
+++ b/ckanext/data_qld_theme/templates/package/comment_list.html
@@ -99,9 +99,9 @@
                     <div class="comment-header-text">
                         {% set commented_on = 'commented on ' + h.render_datetime(comment.creation_date, "%d %b %Y, %-I:%M%p") %}
                         {% if 'user_state' in comment and comment.user_state == 'deleted' %}
-                            <em>{{ comment.user_login_name }}</em> {{ commented_on }}
+                            <em>{{ comment.username }}</em> {{ commented_on }}
                         {% else %}
-                            {% link_for _(comment.user_login_name), named_route='user.read', id=comment.user_id %} {{ commented_on }}
+                            {% link_for _(comment.username), named_route='user.read', id=comment.user_id %} {{ commented_on }}
                         {% endif %}
                         {% if comment.modified_date %}
                         &mdash; <small>({{ _('Modified') }} {{ h.render_datetime(comment.modified_date, "%d %b %Y, %-I:%M%p") }})</small>

--- a/ckanext/data_qld_theme/templates/scheming/package/resource_read.html
+++ b/ckanext/data_qld_theme/templates/scheming/package/resource_read.html
@@ -5,8 +5,8 @@
 {%- block resource_last_updated -%}
   {% do h.populate_revision(res) %}
   <tr>
-    <th scope="row">{{ _('Last updated') }}</th>
-     <td>{{ h.render_datetime(res.revision_timestamp) or h.render_datetime(res.last_modified) or h.render_datetime(res.created) or _('unknown') }}</td>
+    <th scope="row">{{ _('Data last updated') }}</th>
+     <td>{{ h.render_datetime(res.last_modified) or h.render_datetime(res.created) or _('unknown') }}</td>
   </tr>
 {%- endblock -%}
 {%- block resource_created -%}

--- a/ckanext/data_qld_theme/templates/scheming/package/snippets/package_form.html
+++ b/ckanext/data_qld_theme/templates/scheming/package/snippets/package_form.html
@@ -3,7 +3,7 @@
 {% block delete_button %}
   {% resource 'data_qld_theme/dataset-deletion-confirm-action.js' %}
 
-  {% if h.check_access('package_delete', {'id': data.id}) and not data.state == 'deleted' %}
+  {% if c.action == 'edit' and h.check_access('package_delete', {'id': data.id}) and not data.state == 'deleted' %}
     <button disabled="disabled" class="btn btn-danger pull-left"
        data-module-href="{% url_for controller='package', action='delete', id=data.id %}"
        data-module-with-data="true"

--- a/ckanext/data_qld_theme/templates/scheming/package/snippets/package_form.html
+++ b/ckanext/data_qld_theme/templates/scheming/package/snippets/package_form.html
@@ -1,0 +1,15 @@
+{% ckan_extends %}
+
+{% block delete_button %}
+  {% resource 'data_qld_theme/dataset-deletion-confirm-action.js' %}
+
+  {% if h.check_access('package_delete', {'id': data.id}) and not data.state == 'deleted' %}
+    <button disabled="disabled" class="btn btn-danger pull-left"
+       data-module-href="{% url_for controller='package', action='delete', id=data.id %}"
+       data-module-with-data="true"
+       data-module="dataset-deletion-confirm-action"
+       data-module-content="{{ _('Deleting this dataset will prevent future use of the dataset’s name. It is highly recommended that dataset issues are rectified rather than deleting and creating a new dataset with the same information.') }}">
+      {% block delete_button_text %}{{ _('Delete') }}{% endblock %}
+    </button>
+  {% endif %}
+{% endblock %}

--- a/ckanext/data_qld_theme/templates/user/new_user_form.html
+++ b/ckanext/data_qld_theme/templates/user/new_user_form.html
@@ -3,7 +3,7 @@
 <form id="user-register-form" action="" method="post">
   {{ form.errors(error_summary) }}
   {{ form.input("name", id="field-username", label=_("Username"), placeholder=_("username"), value=data.name, error=errors.name, classes=["control-medium"], is_required=True) }}
-  {{ form.input("fullname", id="field-fullname", label=_("Full Name"), placeholder=_("Joe Bloggs"), value=data.fullname, error=errors.fullname, classes=["control-medium"], is_required=True) }}
+  {{ form.input("fullname", id="field-fullname", label=_("Displayed name"), placeholder=_("Joe Bloggs"), value=data.fullname, error=errors.fullname, classes=["control-medium"], is_required=True) }}
   {{ form.input("email", id="field-email", label=_("Email"), type="email", placeholder=_("joe@example.com"), value=data.email, error=errors.email, classes=["control-medium"], is_required=True) }}
   {{ form.input("password1", id="field-password", label=_("Password"), type="password", placeholder="••••••••", value=data.password1, error=errors.password1, classes=["control-medium"], is_required=True) }}
   {{ form.input("password2", id="field-confirm-password", label=_("Confirm"), type="password", placeholder="••••••••", value=data.password2, error=errors.password1, classes=["control-medium"], is_required=True) }}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,9 +5,7 @@ flake8==3.8.3
 nose==1.3.7
 splinter>=0.13.0
 -e git+https://github.com/qld-gov-au/ckanext-datarequests@2.1.3-qgov#egg=ckanext-datarequests
-# -e git+https://github.com/qld-gov-au/ckanext-data-qld@develop#egg=ckanext-data_qld
-#TODO: Change back to qld-gov-au for PR back to qld-gov-au
--e git+https://github.com/salsadigitalauorg/ckanext-data-qld@develop#egg=ckanext-data_qld
+-e git+https://github.com/qld-gov-au/ckanext-data-qld@develop#egg=ckanext-data_qld
 -e git+https://github.com/qld-gov-au/ckanext-archiver.git@2.1.1-qgov.6#egg=ckanext-archiver
 -e git+https://github.com/qld-gov-au/ckanext-qa.git@2.0.3-qgov.3#egg=ckanext-qa
 -e git+https://github.com/qld-gov-au/ckanext-report@0.2#egg=ckan-report

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,9 @@ flake8==3.8.3
 nose==1.3.7
 splinter>=0.13.0
 -e git+https://github.com/qld-gov-au/ckanext-datarequests@2.1.3-qgov#egg=ckanext-datarequests
--e git+https://github.com/qld-gov-au/ckanext-data-qld@develop#egg=ckanext-data_qld
+# -e git+https://github.com/qld-gov-au/ckanext-data-qld@develop#egg=ckanext-data_qld
+#TODO: Change back to qld-gov-au for PR back to qld-gov-au
+-e git+https://github.com/salsadigitalauorg/ckanext-data-qld@develop#egg=ckanext-data_qld
 -e git+https://github.com/qld-gov-au/ckanext-archiver.git@2.1.1-qgov.6#egg=ckanext-archiver
 -e git+https://github.com/qld-gov-au/ckanext-qa.git@2.0.3-qgov.3#egg=ckanext-qa
 -e git+https://github.com/qld-gov-au/ckanext-report@0.2#egg=ckan-report


### PR DESCRIPTION
Hi @duttonw & @ThrawnCA ,

This PR includes the following stories from sprint 2:
- [Display of Data last updated values](https://salsadigital.atlassian.net/browse/DQL3-8)
- [Display a user’s ‘Full name’ in all instances where that user’s activity is given attribution](https://salsadigital.atlassian.net/browse/DQL3-10)
- [Changes to the user account creation and ‘Full name’ field](https://salsadigital.atlassian.net/browse/DQL3-11)
- [Changes to process for the deletion of datasets](https://salsadigital.atlassian.net/browse/DQL3-12)

