### PR TITLE
User edit form fix

### DIFF
--- a/ckanext/data_qld_theme/templates/user/edit.html
+++ b/ckanext/data_qld_theme/templates/user/edit.html
@@ -5,7 +5,7 @@
     <h2 class="module-heading"><i class="fa fa-info-circle"></i> {{ _('Account Info') }}</h2>
     <div class="module-content">
       {% trans %}
-        Registered users can make data requests, comment against data requests and give dataset feedback. Your ‘Displayed name’ will be publicly visible against your contributions.
+        Registered users can make data requests, comment against data requests and give dataset feedback. Your 'Displayed name' will be publicly visible against your contributions.
       {% endtrans %}
     </div>
   </section>

--- a/ckanext/data_qld_theme/templates/user/edit.html
+++ b/ckanext/data_qld_theme/templates/user/edit.html
@@ -5,7 +5,7 @@
     <h2 class="module-heading"><i class="fa fa-info-circle"></i> {{ _('Account Info') }}</h2>
     <div class="module-content">
       {% trans %}
-        “Registered users can make data requests, comment against data requests and give dataset feedback. Your ‘Displayed name’ will be publicly visible against your contributions.” 
+        Registered users can make data requests, comment against data requests and give dataset feedback. Your ‘Displayed name’ will be publicly visible against your contributions.
       {% endtrans %}
     </div>
   </section>

--- a/ckanext/data_qld_theme/templates/user/edit.html
+++ b/ckanext/data_qld_theme/templates/user/edit.html
@@ -1,0 +1,12 @@
+{% ckan_extends %}
+
+{% block secondary_content %}
+  <section class="module module-narrow module-shallow">
+    <h2 class="module-heading"><i class="fa fa-info-circle"></i> {{ _('Account Info') }}</h2>
+    <div class="module-content">
+      {% trans %}
+        “Registered users can make data requests, comment against data requests and give dataset feedback. Your ‘Displayed name’ will be publicly visible against your contributions.” 
+      {% endtrans %}
+    </div>
+  </section>
+{% endblock %}

--- a/ckanext/data_qld_theme/templates/user/new.html
+++ b/ckanext/data_qld_theme/templates/user/new.html
@@ -3,6 +3,6 @@
   {% block help_inner %}
   <h2 class="module-heading">{{ _('Why Sign Up?') }}</h2>
   <div class="module-content">
-    <p>{% trans %}Users must register to make data requests, comment against data requests and to give dataset feedback.{% endtrans %}</p>
+    <p>{% trans %}“Registered users can make data requests, comment against data requests and give dataset feedback. Your ‘Displayed name’ will be publicly visible against your contributions.” {% endtrans %}</p>
   </div>
   {% endblock %}

--- a/ckanext/data_qld_theme/templates/user/new.html
+++ b/ckanext/data_qld_theme/templates/user/new.html
@@ -3,6 +3,6 @@
   {% block help_inner %}
   <h2 class="module-heading">{{ _('Why Sign Up?') }}</h2>
   <div class="module-content">
-    <p>{% trans %}Registered users can make data requests, comment against data requests and give dataset feedback. Your ‘Displayed name’ will be publicly visible against your contributions. {% endtrans %}</p>
+    <p>{% trans %}Registered users can make data requests, comment against data requests and give dataset feedback. Your 'Displayed name' will be publicly visible against your contributions. {% endtrans %}</p>
   </div>
   {% endblock %}

--- a/ckanext/data_qld_theme/templates/user/new.html
+++ b/ckanext/data_qld_theme/templates/user/new.html
@@ -3,6 +3,6 @@
   {% block help_inner %}
   <h2 class="module-heading">{{ _('Why Sign Up?') }}</h2>
   <div class="module-content">
-    <p>{% trans %}“Registered users can make data requests, comment against data requests and give dataset feedback. Your ‘Displayed name’ will be publicly visible against your contributions.” {% endtrans %}</p>
+    <p>{% trans %}Registered users can make data requests, comment against data requests and give dataset feedback. Your ‘Displayed name’ will be publicly visible against your contributions. {% endtrans %}</p>
   </div>
   {% endblock %}


### PR DESCRIPTION
HI @duttonw ,

This fixes the issue you are seeing on the user edit form.
It was using a Unicode single quote most likely copied and pasted from the Jira ticket and needs to be an ASCII single quote.
This caused an issue with the ckanext-csrf-filter extension throwing an exception error while trying to insert the token on the form.
`*** UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 6599: ordinal not in range(128)`