### PR TITLE
[QOL-8595] restore controller-based routing for re-opening data requests

### DIFF
--- a/ckanext/data_qld_theme/templates/datarequests/show.html
+++ b/ckanext/data_qld_theme/templates/datarequests/show.html
@@ -18,7 +18,7 @@
   {% endif %}
 
   {% if h.check_access('open_datarequest', {'id':datarequest_id }) and c.datarequest.closed %}
-    {% link_for _('Re-open'), named_route='open_datarequest', id=datarequest_id, class_='btn btn-success', icon='unlock' %}
+    {% link_for _('Re-open'), controller='ckanext.data_qld.controller:DataQldUI', action='open_datarequest', id=datarequest_id, class_='btn btn-success', icon='unlock' %}
   {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
Looks like old ckanext-data-qld doesn't provide any named route at all.