### PR TITLE
Develop to master

### DIFF
--- a/ckanext/data_qld_theme/templates/datarequests/show.html
+++ b/ckanext/data_qld_theme/templates/datarequests/show.html
@@ -18,7 +18,7 @@
   {% endif %}
 
   {% if h.check_access('open_datarequest', {'id':datarequest_id }) and c.datarequest.closed %}
-    {% link_for _('Re-open'), named_route='open_datarequest', id=datarequest_id, class_='btn btn-success', icon='unlock' %}
+    {% link_for _('Re-open'), controller='ckanext.data_qld.controller:DataQldUI', action='open_datarequest', id=datarequest_id, class_='btn btn-success', icon='unlock' %}
   {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
Restore controller-based routing of data request re-opening for now.

This will be resolved properly in the combined ckanext-data-qld extension.